### PR TITLE
fix(docs) update cwd spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Use absolute paths. "${workspaceFolder}" can be used, it equals to the current w
 
 **"port"** - in the case of "attach", this is the port to connect to. Must be present.
 
-**"cmd"** - working directory for running the script. Defaults to (n)vims current directory. Optional.
+**"cwd"** - working directory for running the script. Defaults to (n)vims current directory. Optional.
 
 **"envFile"** - path to a file containing environment variables. Optional.
 

--- a/doc/vim-node-inspect.txt
+++ b/doc/vim-node-inspect.txt
@@ -86,7 +86,7 @@ The configuration file name is 'vim-node-inspect.json' and the plugin searches f
 "restart" - in the case of "attach", restarts the debug session if the connection breaks. Useful when using a process monitor such as nodemon or pm2. 
 "localRoot" - defines the local directory when connecting to a running container. See VimNodeInspectContainers. 
 "remoteRoot" -  defines the remote directory when connecting to a running container. See VimNodeInspectContainers. 
-"cmd" - working directory for running the script. Defaults to (n)vims current directory. Optional.
+"cwd" - working directory for running the script. Defaults to (n)vims current directory. Optional.
 "envFile" - path to a file containing environment variables. Optional.
 "env" - JSON object containing environment variables definition. Takes precedence over envFile. Optional.
 


### PR DESCRIPTION
Noticed a couple instances of `"cmd"` where I think `"cwd"` was intended :)