### PR TITLE
Read the config file specified in the docs

### DIFF
--- a/autoload/nodeinspect/config.vim
+++ b/autoload/nodeinspect/config.vim
@@ -1,4 +1,5 @@
-let s:configFileName = 'vim-node-config.json' 
+let s:configFileName = 'vim-node-inspect.json'
+let s:legacyConfigFileName = 'vim-node-config.json'
 
 function! s:removeSessionKeys(session,...)
 	for uvar in a:000

--- a/autoload/nodeinspect/config.vim
+++ b/autoload/nodeinspect/config.vim
@@ -34,20 +34,32 @@ function! s:ReplaceMacros(str)
 	return replaced
 endfunction
 
+function s:getReadableConfigFile(path)
+	let configFilePath = a:path . '/' . s:configFileName
+	if filereadable(configFilePath)
+		return configFilePath
+	endif
+	let legacyConfigFilePath = a:path . '/' . s:legacyConfigFileName
+	if filereadable(legacyConfigFilePath)
+		return legacyConfigFilePath
+	endif
+	return v:false
+endfunction
+
 " find the config file path. if its not in the currend working directory, try
 " going up from the current buffer directory. Returns the directory or empty
 " string if failed to find the config file.
 function s:GetConfigFilePath()
-	let configFilePath = getcwd() . '/' . s:configFileName
-	if filereadable(configFilePath)
+	let configFilePath = s:getReadableConfigFile(getcwd())
+	if configFilePath
 		return configFilePath
 	endif
 	" if the file is not found in pwd and the script is a decedant, try going up  
 	let expandString = '%:p:h'
 	let traverseDir = expand(expandString)
 	while stridx(traverseDir, getcwd()) != -1
-		let configFilePath = traverseDir . '/' . s:configFileName
-		if filereadable(configFilePath)
+		let configFilePath = s:getReadableConfigFile(traverseDir)
+		if configFilePath
 			return configFilePath
 		endif
 		let expandString = expandString . ':h'


### PR DESCRIPTION
Also support the config file we used to read, in case people have
figured it out and are using the name that was previously used by the
code. This fixes #17 