### PR TITLE
Always populate watches key

### DIFF
--- a/autoload/nodeinspect.vim
+++ b/autoload/nodeinspect.vim
@@ -1,3 +1,4 @@
+" vim: noet
 let s:status = 0 " 0 - not started. 1 - started 2 - session ended (bridge exists, node exited) 3 - restarting
 let s:plugin_path = expand('<sfile>:h:h')
 let s:sign_id = 2
@@ -128,7 +129,7 @@ function! s:getRemoteFilePath(file)
 		return a:file
 	endif
 	" strip file of its path, add it to the remote
-	let remoteFile = substitute(a:file,	s:session["localRoot"], s:session["remoteRoot"], "")
+	let remoteFile = substitute(a:file, s:session["localRoot"], s:session["remoteRoot"], "")
 	return remoteFile
 endfunction
 
@@ -333,7 +334,7 @@ endfunction
 " called when the debug session ended from external job (exec via npm for
 " example)
 function! nodeinspect#onDebuggerEnded()
-    call s:onDebuggerHalted()
+	call s:onDebuggerHalted()
 endfunction
 
 
@@ -527,7 +528,7 @@ endfunction
 
 " starts node-inspect. connects to the node bridge.
 function! s:NodeInspectStart()
-	" set configuration defaults 	
+	" set configuration defaults
 	call  nodeinspect#config#SetConfigurationDefaults(s:session)
 	" load configuration. if execution is specified there it shall be used.  
 	" clear configuration in here as it can't be done when passing a variable
@@ -584,7 +585,7 @@ function! s:NodeInspectStart()
 		endif
 		" set the status to running, might be at ended(2)
 		let s:status = 3
-        " restarting might need to restart external jobs, if any
+		" restarting might need to restart external jobs, if any
 		let repl_result = nodeinspect#repl#StartExternalJobs(s:session)
 		if repl_result != 0
 			call nodeinspect#backtrace#ClearBacktraceWindow('node-inspect restart error')
@@ -695,7 +696,7 @@ function! nodeinspect#NodeInspectRun(...)
 		let s:session["script"] = expand('%:p')
 		let s:session["initialLaunchBreak"] = 1
 		let s:session["args"] = a:000[:]
-    call s:NodeInspectStart()
+		call s:NodeInspectStart()
 	else
 		call s:NodeInspectRun()
 	endif

--- a/autoload/nodeinspect.vim
+++ b/autoload/nodeinspect.vim
@@ -6,7 +6,7 @@ let s:sign_group = 'visgroup'
 let s:sign_cur_exec = 'vis'
 let s:sign_brkpt = 'visbkpt'
 let s:breakpoints = {}
-let s:session = {}
+let s:session = {"watches": {}}
 let s:breakpointsUnhandledBuffers = {}
 let s:sessionFile = s:plugin_path . '/vim-node-session.json'
 let s:msgDelimiter = '&&'
@@ -613,10 +613,7 @@ function! s:NodeInspectStart()
 		endif
 	endif
 	" redraw the watch window; draws any watches added from the session
-	for watch in keys(s:session["watches"])
-		call nodeinspect#watches#AddBulk(s:session["watches"])
-	endfor
-
+	call nodeinspect#watches#AddBulk(s:session["watches"])
 endfunction
 
 

--- a/autoload/nodeinspect/backtrace.vim
+++ b/autoload/nodeinspect/backtrace.vim
@@ -1,3 +1,4 @@
+" vim: noet
 let s:backtrace_win = -1
 let s:backtrace_buf = -1
 
@@ -65,14 +66,14 @@ function! nodeinspect#backtrace#ShowBacktraceWindow(startWin)
 			else
 				execute "rightb ".winwidth(a:startWin)/3."vnew | setlocal nobuflisted buftype=nofile statusline=Callstack"
 			endif
-			
+
 			let s:backtrace_buf = bufnr('%')
 			set nonu
 		else
 			if g:nodeinspect_window_pos == 'right' || g:nodeinspect_window_pos == 'left'
 				execute winheight(a:startWin)/3."new | buffer ". s:backtrace_buf
 			else
-				execute "rightb ".winwidth(a:startWin)/3."vnew | buffer ". s:backtrace_buf 
+				execute "rightb ".winwidth(a:startWin)/3."vnew | buffer ". s:backtrace_buf
 			endif
 		endif
 		let s:backtrace_win = win_getid()

--- a/autoload/nodeinspect/config.vim
+++ b/autoload/nodeinspect/config.vim
@@ -1,4 +1,5 @@
-let s:configFileName = 'vim-node-config.json' 
+" vim: noet
+let s:configFileName = 'vim-node-config.json'
 
 function! s:removeSessionKeys(session,...)
 	for uvar in a:000
@@ -17,9 +18,9 @@ function! nodeinspect#config#SetConfigurationDefaults(session)
 	let a:session["cwd"] = getcwd()
 	let a:session["envFile"] = ""
 	let a:session["env"] = ""
-    let a:session["runtimeExecutable"] = ""
-    let a:session["runtimeArgs"] = []
-    let a:session["exJob"] = -1
+	let a:session["runtimeExecutable"] = ""
+	let a:session["runtimeArgs"] = []
+	let a:session["exJob"] = -1
 endfunction
 
 
@@ -42,7 +43,7 @@ function s:GetConfigFilePath()
 	if filereadable(configFilePath)
 		return configFilePath
 	endif
-	" if the file is not found in pwd and the script is a decedant, try going up  
+	" if the file is not found in pwd and the script is a decedant, try going up
 	let expandString = '%:p:h'
 	let traverseDir = expand(expandString)
 	while stridx(traverseDir, getcwd()) != -1
@@ -79,7 +80,7 @@ function! nodeinspect#config#LoadConfigFile(session)
 		" configPtr holds the used configuration
 		let configObj = json_decode(fullFile)
 		let configPtr = v:null
-		if type(configObj) == v:t_dict 
+		if type(configObj) == v:t_dict
 			" test wherever its a multi configuration
 			if has_key(a:session, "configName") == 1 || has_key(configObj,"configurations") == 1
 				" validation, the first arg must be present and be the config name
@@ -99,7 +100,7 @@ function! nodeinspect#config#LoadConfigFile(session)
 						endif
 					endfor
 				endif
-				if type(configPtr) != v:t_dict	
+				if type(configPtr) != v:t_dict
 					echom "vim-node-inspect - can't find configuration error"
 					return 1
 				endif
@@ -111,10 +112,10 @@ function! nodeinspect#config#LoadConfigFile(session)
 				let configuration["remoteRoot"] = configPtr["remoteRoot"]
 				" add trailing backslash if not present. it will normalize both inputs
 				" in case the user add one with and one without
-				if configuration["localRoot"][-1:-1] != '/' 
+				if configuration["localRoot"][-1:-1] != '/'
 					let configuration["localRoot"] = configuration["localRoot"] . '/'
 				endif
-				if configuration["remoteRoot"][-1:-1] != '/' 
+				if configuration["remoteRoot"][-1:-1] != '/'
 					let configuration["remoteRoot"] = configuration["remoteRoot"] . '/'
 				endif
 			endif
@@ -198,17 +199,17 @@ function! nodeinspect#config#LoadConfigFile(session)
 			endif
 
 			if has_key(configPtr,"runtimeArgs") == 1
-                if type(configPtr["runtimeArgs"]) == 3
-                    let a:session["runtimeArgs"] = configPtr["runtimeArgs"]
-                else
-                    echom "error reading runtimeArgs in vim-node-inspect"
-                    return 1
-                endif
+				if type(configPtr["runtimeArgs"]) == 3
+					let a:session["runtimeArgs"] = configPtr["runtimeArgs"]
+				else
+					echom "error reading runtimeArgs in vim-node-inspect"
+					return 1
+				endif
 			endif
 
 			" validate config and setup session
-			if has_key(configuration, "request") == 1 
-				if configuration["request"] == 'attach' 
+			if has_key(configuration, "request") == 1
+				if configuration["request"] == 'attach'
 					if has_key(configuration, "port") == 0
 						echom "vim-node-inspect config error, attach without a port"
 						return 1
@@ -223,7 +224,7 @@ function! nodeinspect#config#LoadConfigFile(session)
 						endif
 					endif
 				endif
-				if configuration["request"] == 'launch' 
+				if configuration["request"] == 'launch'
 					if has_key(configuration, "restart") == 1
 						echom "vim-node-inspect config error, restart in invalid in launch mode"
 						return 1

--- a/autoload/nodeinspect/repl.vim
+++ b/autoload/nodeinspect/repl.vim
@@ -1,3 +1,4 @@
+" vim: noet
 let s:repl_win = -1
 let s:repl_buf = -1
 let s:term_id = -1
@@ -6,103 +7,103 @@ let s:ex_job = -1 " id for nvim, job object for vim
 
 
 function! IsExJobRunning()
-    if has("nvim")
-       if s:ex_job != -1
-           return 1
-        endif
-    else
-        if type(s:ex_job) == v:t_job && job_status(s:ex_job) == 'run'
-            return 1
-        endif
-    endif
-    return 0
+	if has("nvim")
+		if s:ex_job != -1
+			return 1
+		endif
+	else
+		if type(s:ex_job) == v:t_job && job_status(s:ex_job) == 'run'
+			return 1
+		endif
+	endif
+	return 0
 endfunction
 
 
 " called when the external command emits to stdout
 function! OnExternalJobStdout(...)
-    if IsExJobRunning()
-        " nvim receives a list while vim receives text
-        if type(a:2) == 3 
-            let data = join(a:2, '\n')
-        else
-            let data = a:2
-        endif
-        call nodeinspect#utils#SendEvent('{"m": "nd_print", "txt":"'.data.'\n"}')
-    endif
+	if IsExJobRunning()
+		" nvim receives a list while vim receives text
+		if type(a:2) == 3
+			let data = join(a:2, '\n')
+		else
+			let data = a:2
+		endif
+		call nodeinspect#utils#SendEvent('{"m": "nd_print", "txt":"'.data.'\n"}')
+	endif
 endfunction
 
 
 
 function! OnExternalJobStderr(...)
-    " nvim receives a list while vim receives text
-    if type(a:2) == 3 
-        let data = join(a:2)
-    else
-        let data = a:2
-    endif
-    let pos = match(data, "Waiting for the debugger to disconnect")
-    if pos != -1 && IsExJobRunning()
-        if has("nvim")
-            call jobstop(s:ex_job)
-        else
-            call job_stop(s:ex_job)
-        endif
-        let s:ex_job = -1
-        call nodeinspect#onDebuggerEnded()
-    endif
+	" nvim receives a list while vim receives text
+	if type(a:2) == 3
+		let data = join(a:2)
+	else
+		let data = a:2
+	endif
+	let pos = match(data, "Waiting for the debugger to disconnect")
+	if pos != -1 && IsExJobRunning()
+		if has("nvim")
+			call jobstop(s:ex_job)
+		else
+			call job_stop(s:ex_job)
+		endif
+		let s:ex_job = -1
+		call nodeinspect#onDebuggerEnded()
+	endif
 endfunction
 
 
 function! OnExternalJobExit(...)
-    if IsExJobRunning()
-        let s:ex_job = -1
-        call nodeinspect#onDebuggerEnded()
-    endif
+	if IsExJobRunning()
+		let s:ex_job = -1
+		call nodeinspect#onDebuggerEnded()
+	endif
 endfunction
 
 " returns -1 on failure or 0 on success
 " though the job id can be used for commmunication (nvim), I won't use it
 " but send a message to the bridge to update the console. It prevents side
-" effects such as it simulates user interaction 
+" effects such as it simulates user interaction
 function! s:getRuntimeExecutableCommand(runtimeExecutable, runTimeArgs, cwd)
-    let ext_cmd = a:runtimeExecutable . " " . join(a:runTimeArgs)
+	let ext_cmd = a:runtimeExecutable . " " . join(a:runTimeArgs)
 	if has("nvim")
 		let ex_job_id = jobstart(ext_cmd, {'cwd': a:cwd, 'on_stdout': 'OnExternalJobStdout', 'on_stderr': 'OnExternalJobStderr', 'on_exit': 'OnExternalJobExit'})
 		" -1 will be returned only if the window opening fails
 		if ex_job_id == -1
 			return -1
 		endif
-        return ex_job_id
+		return ex_job_id
 	else
 		let ex_job = job_start(ext_cmd, {'exit_cb': 'OnExternalJobExit', 'cwd': a:cwd, 'out_cb': 'OnExternalJobStdout','err_cb': 'OnExternalJobStderr'})
 		" 0 will be returned only if the window opening fails
 		if job_status(ex_job) != 'run'
-            echom "can't start job!"
+			echom "can't start job!"
 			return -1
 		endif
-        return ex_job
+		return ex_job
 	endif
 endfunction
 
 
 function! s:startExternalJobs(session)
-    " execute external command, if any
-    if a:session["runtimeExecutable"] != ""
-        let s:ex_job = s:getRuntimeExecutableCommand(a:session["runtimeExecutable"], a:session["runtimeArgs"],a:session["cwd"])
-        if !IsExJobRunning()
-            echom "failed to execute external command"
-            return
-        endif
-        let a:session["exJob"] = s:ex_job
-    endif
+	" execute external command, if any
+	if a:session["runtimeExecutable"] != ""
+		let s:ex_job = s:getRuntimeExecutableCommand(a:session["runtimeExecutable"], a:session["runtimeArgs"],a:session["cwd"])
+		if !IsExJobRunning()
+			echom "failed to execute external command"
+			return
+		endif
+		let a:session["exJob"] = s:ex_job
+	endif
 endfunction
 
 
 " called when restarting node-inspect, external jobs and other non-repl
 " windows related job need to restart
 function nodeinspect#repl#StartExternalJobs(session)
-    call s:startExternalJobs(a:session)
+	call s:startExternalJobs(a:session)
 endfunction
 
 
@@ -112,18 +113,18 @@ function nodeinspect#repl#StartNodeInspect(session, plugin_path)
 		echom "nodeinspect - can't start repl"
 		return
 	endif
-    " find an open port
+	" find an open port
 	let cmd_line = []
 	call add(cmd_line, 'node')
 	call add(cmd_line, a:plugin_path . "/node-inspect/find_port.js")
 	if has("nvim")
-        let a:session['bridge_port'] = system(cmd_line)
-    else
-        let a:session['bridge_port'] = system(join(cmd_line, ' '))
-    endif
-    if v:shell_error == -1
-        return 1
-    endif
+		let a:session['bridge_port'] = system(cmd_line)
+	else
+		let a:session['bridge_port'] = system(join(cmd_line, ' '))
+	endif
+	if v:shell_error == -1
+		return 1
+	endif
 	" prepare call command line
 	let cmd_line = []
 	call add(cmd_line, 'node')
@@ -131,9 +132,9 @@ function nodeinspect#repl#StartNodeInspect(session, plugin_path)
 	call add(cmd_line, a:session['bridge_port'])
 	" start according to settings
 	if a:session["request"] == "launch"
-        " add the relevant launch params
-        call add(cmd_line, a:session["script"])
-        let cmd_line += a:session["args"]
+		" add the relevant launch params
+		call add(cmd_line, a:session["script"])
+		let cmd_line += a:session["args"]
 	else
 		" add the relevant connect params
 		call add(cmd_line, a:session["address"].":".a:session["port"])
@@ -148,16 +149,16 @@ function nodeinspect#repl#StartNodeInspect(session, plugin_path)
 		let s:term_id = term_start(cmd_line, {'curwin': 1, 'exit_cb': 'OnNodeInspectExit', 'term_finish': 'close', 'term_kill': 'kill', 'cwd': a:session["cwd"]})
 		" 0 will be returned only if the window opening fails
 		if s:term_id == 0
-            " to keep similar with nvim
-            let s:term_id = -1
+			" to keep similar with nvim
+			let s:term_id = -1
 			return 1
 		endif
 	endif
 	sleep 200m
-    " set the cursor at the bottom to enable scrolling
-    execute "norm G"
-    " execute any external jobs
-    call s:startExternalJobs(a:session)
+	" set the cursor at the bottom to enable scrolling
+	execute "norm G"
+	" execute any external jobs
+	call s:startExternalJobs(a:session)
 	return 0
 endfunction
 
@@ -213,7 +214,7 @@ function nodeinspect#repl#KillReplWindow()
 	if s:repl_win != -1 && win_gotoid(s:repl_win) == 1
 		execute "bd!"
 		let s:repl_buf = -1
-        let s:term_id = -1
+		let s:term_id = -1
 	endif
 endfunction
 

--- a/autoload/nodeinspect/utils.vim
+++ b/autoload/nodeinspect/utils.vim
@@ -1,20 +1,21 @@
+" vim: noet
 let s:channel = 0
 
 
 " send event to node bridge
 function! nodeinspect#utils#SendEvent(e)
-	if has("nvim") 
+	if has("nvim")
 		if s:channel > 0
 			call chansend(s:channel, a:e)
 		endif
 	elseif type(s:channel) == 9 && ch_status(s:channel) == "open"
 		call ch_sendraw(s:channel, a:e)
-        sleep 5m
+		sleep 5m
 	endif
 endfunction
 
 
-" connects to the bridge, up to 3s. 
+" connects to the bridge, up to 3s.
 " returns 1 if connected successfully, otherwise 0
 function! nodeinspect#utils#ConnectToBridge(session)
 	let retries = 15
@@ -37,20 +38,20 @@ function! nodeinspect#utils#ConnectToBridge(session)
 		let retries -= 1
 	endwhile
 	if connected == 1
-		call nodeinspect#utils#SendEvent('{"m": "nd_init", "autoWatches":'. g:nodeinspect_auto_watch .  ', "envFile": "'. a:session["envFile"] .'" , "env": "'. escape(a:session["env"], '"') . '"}')
+		call nodeinspect#utils#SendEvent('{"m": "nd_init", "autoWatches":'. g:nodeinspect_auto_watch .	', "envFile": "'. a:session["envFile"] .'" , "env": "'. escape(a:session["env"], '"') . '"}')
 	endif
 	return connected
 endfunction
 
 
 function nodeinspect#utils#CloseChannel()
-	if has("nvim") 
+	if has("nvim")
 		if s:channel > 0
 			call chanclose(s:channel)
 		endif
 	elseif type(s:channel) == 9 && ch_status(s:channel) == "open"
 		call ch_close(s:channel)
-	endif	
+	endif
 endfunction
 
 

--- a/autoload/nodeinspect/watches.vim
+++ b/autoload/nodeinspect/watches.vim
@@ -1,3 +1,4 @@
+" vim: noet
 let s:inspect_win = -1
 let s:inspect_buf = -1
 let s:watches = {}
@@ -46,7 +47,7 @@ function s:RecalcWatchesKeys()
 			let line = trim(getline(currentLine))
 			" don't recalc autos
 			if len(line) != 0 && line[:(len(s:auto_sign)-1)] != s:auto_sign
-				let firstWord = split(line)[0]	
+				let firstWord = split(line)[0]
 				let s:watches[firstWord] = "n/a"
 			endif
 			let currentLine += 1


### PR DESCRIPTION
As mentioned in the commit note, this shouldn't usually be a problem, but I reloaded `nodeinspect.vim` when doing other debugging and started getting an error about the watches key missing. Since we do access it without checking, I figure it might as well just set watches to an empty object from file init.

While here I also noticed that there was an unnecessary loop, presumably left over from earlier refactoring, and also some spacing inconsistency, so I fixed up the spacing and added modelines to hopefully keep things more consistent moving forward.